### PR TITLE
revisión mpg.yml

### DIFF
--- a/inst/specs/mpg.yml
+++ b/inst/specs/mpg.yml
@@ -4,26 +4,35 @@ df:
 variables:
   manufacturer:
     trans: fabricante
+    desc: fabricante
   model:
     trans: modelo
+    desc: nombre del modelo
   displ:
-    trans: cilindrada
+    trans: motor
+    desc: tamaño del motor del automóvil, en litros
   year:
     trans: anio
+    desc: año de fabricación
   cyl:
     trans: cilindros
+    desc: número de cilindros
   trans:
     trans: transmision
+    desc: tipo de transmisión
   drv:
     trans: traccion
     values:
       f: d
       r: t
       4: 4
+    desc: tipo de tracción (d = delantera, t = trasera, 4 = 4 ruedas)
   cty:
     trans: ciudad
+    desc: millas por galón de combustible en ciudad
   hwy:
     trans: autopista
+    desc: millas por galón de combustible en autopista
   fl:
     trans: combustible
     values:
@@ -32,6 +41,7 @@ variables:
       e: e
       d: d
       c: g
+    desc: tipo de combustible (p = premium, r = regular, e = etanol, d = diesel, g = gas natural comprimido)
   class:
     trans: clase
     values:
@@ -42,3 +52,11 @@ variables:
       pickup: pickup
       subcompact: subcompacto
       suv: suv
+    desc: "tipo" de auto
+help:
+  name: millas
+  alias: millas
+  title: Datos de economía de combustible de 1999 y 2008 para 38 modelos populares de automóviles
+  description: Este conjunto de datos contiene un subconjunto de los datos de economía de combustible que la Agencia de Protección Medioambiental (EPA) pone a disposición en http://fueleconomy.gov. Contiene solo modelos que tuvieron una nueva versión cada año entre 1999 y 2008, lo que fue utilizado como un proxy de la popularidad del automóvil.
+  usage: millas
+  format: Un dataframe con 234 filas y 11 variables


### PR DESCRIPTION
Descripción de las variables + help. 
Hice una nueva propuesta de traducción de la variable `displ`. Estaba como "cilindrada", pero como también hay otra variables que es "cilindros", podría eventualmente prestarse a confusión. Como `displ` apunta al tamaño del motor en litros, la dejé como `motor` (pensando que informalmente se suele decir que un auto " tiene un motor de X litros"). 