### PR TITLE
yaml para traducir mtcars

### DIFF
--- a/inst/specs/mtcars.yml
+++ b/inst/specs/mtcars.yml
@@ -1,0 +1,44 @@
+df:
+  source: datasets::mtcars
+  name: mtautos
+variables:
+  mpg:
+    trans: millas
+    desc: millas por galón de Estados Unidos
+  cyl:
+    trans: cilindros
+    desc: número de cilindros
+  disp:
+    trans: cilindrada
+    desc: suma del volumen útil de todos los cilindros del motor en pulgadas cúbicas
+  hp:
+    trans: caballos
+    desc: caballos de fuerza brutos
+  drat:
+    trans: eje
+    desc: relación del eje de transmisión trasero
+  wt:
+    trans: peso
+    desc: peso (1000 libras)
+  qsec:
+    trans: velocidad
+    desc: tiempo en recorrer 1/4 de milla
+  vs:
+    trans: forma
+    desc: forma del motor (en V o en línea)
+  am:
+    trans: transmision
+    desc: tipo de transmisión (0 = automático, 1 = manual)
+  gear:
+    trans: cambios
+    desc: número de cambios de la caja de cambios
+  carb:
+    trans: carburadores
+    desc: número de carburadores
+help:
+  name: mtautos
+  alias: mtautos
+  title: Pruebas de ruta de automóviles de Motor Trend
+  description: Los datos fueron extraídos de la revista Motor Trend de Estados Unidos de 1974, y tiene datos de consumo de combustible y 10 aspectos de diseño y performance de automóviles para 32 automóviles (modelos de 1973-73).
+  usage: mtautos
+  format: Un data frame con 32 observaciones y 11 variables


### PR DESCRIPTION
Me costó mucho porque es un vocabulario muy específico y que no manejo, así que sería bueno que alguien que maneje mejor estos términos lo mire con detenimiento.

La variable `vs` vale `0` o `1` pero en ningún lugar aclara cuál es `v` y cuál `s`. Esta variable se refiere a la forma del motor, si es en forma de "V" o "straight" (en línea).

Independientemente de todo esto, todas las variables son numéricas en el dataset.