### PR TITLE
Translate 'sentences' as 'oraciones' and other requested fixes

### DIFF
--- a/inst/specs/sentences.yml
+++ b/inst/specs/sentences.yml
@@ -1,10 +1,10 @@
 df:
   source: stringr::sentences
-name: sentences
+name: oraciones
 help:
-  name: sentences
-alias: sentences
+  name: oraciones
+alias: oraciones
 title: Muestra de vector de caracteres para practicar manipulacion de cadena de caracteres.
-description: `sentences` es una colección de "Harvard sentences" usada para pruebas estandarizadas de voz.
-usage: diamantes
+description: oraciones es una colección de "Harvard sentences" usada para pruebas estandarizadas de voz.
+usage: oraciones
 format: Una cadena de caracteres con 720 elmentos.


### PR DESCRIPTION
Translate 'sentences' as 'oraciones', remove back-ticks from 'description', and fix usage. (Closes #43)