### PR TITLE
Add .travis.yml to .Rbuildignore to avoid R CMD check note

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
+^\.travis\.yml$
 ^docs$
 ^_pkgdown\.yml$
 ^README\.Rmd$


### PR DESCRIPTION
The commit d9e0c79 added .travis.yml but the file wasn't added to .Rbuildignore. This results in the following note during devtools::check():

> Found the following hidden files and directories: .travis.yml

This commit fixes this problem.