### PR TITLE
update README, flights, faithful & airplanes

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -43,7 +43,14 @@ translated <- paste0("'", paste0(d, collapse = "', '"), "'")
 knitr::kable(data.frame(Paquetes = as.character(unique(packages))))
 ```
 
-Salvo `gapminder`, `Lahman` y `nycflights13`, todos vienen incluidos en el `tidyverse` o en R base. 
+El paquete `datasets` es parte de R base y `ggplot2`, `tibble`, `tidyr`, `readr` y `forcats` vienen incluidos en el Tidyverse. Todos los demás deben instalarse individualmente. 
+
+Si el paquete necesario no está instalado, al tratar de utilizar los datos traducidos aparecerá un error como el siguiente:
+
+```
+> datos::vuelos
+ Error in loadNamespace(name) : there is no package called ‘nycflights13‘
+```
 
 ## Traducciones
 
@@ -55,11 +62,11 @@ datos <- results$matches[c("Name", "Title")]
 knitr::kable(stats::setNames(datos, c("Nombre", "Título")))
 ```
 
-Además, se incluyen tres set de datos para practicar la manipulación de cadenas (_strings_): `oraciones`, `palabras` y `fruta`. 
+Los datos para practicar la manipulación de cadenas (_strings_) son `oraciones`, `palabras` y `frutas`. 
 
 ## Uso
 
-La libreria `datos` tiene que ser cargada explícitamente en la sesión de R:
+El paquete `datos` se carga igual que todos los paquetes de R: 
 
 ```{r}
 library(datos)
@@ -67,13 +74,13 @@ library(ggplot2)
 library(dplyr)
 ```
 
-Las variables que contienen los datos van a estar disponibles inmediatamente para su uso, pero los datos no se van a traducir hasta que la variable sea "llamada" explícitamente en el código que se escriba. En este ejemplo, los datos `diamantes`, que provienen de `ggplot2::diamonds`, se cargan en la memoria de R cuando los llamamos por primera vez en español:
+Las variables que contienen los datos van a estar disponibles inmediatamente para su uso, pero los datos no se traducirán hasta que la variable sea "llamada" explícitamente en el código que se escriba. En este ejemplo, el _dataset_ `diamantes`, que proviene de `ggplot2::diamonds`, se carga en la memoria de R en el momento en que lo llamamos por primera vez en español:
 
 ```{r}
 glimpse(diamantes)
 ```
 
-Una vez cargado en la memoria, `diamantes` se puede utilizar como cualquier otro _dataset_ en R:
+Los datos traducidos quedarán cargados durante toda la sesión de R:
 
 ```{r}
 diamantes %>%

--- a/README.md
+++ b/README.md
@@ -1,44 +1,33 @@
 
-# datos <img src="man/figures/logo.png" align="right" width = "120px"/>
+datos <img src="man/figures/logo.png" align="right" width = "120px"/>
+=====================================================================
 
-[![CRAN
-status](https://www.r-pkg.org/badges/version/datos)](https://cran.r-project.org/package=datos)
-[![Travis-CI Build
-Status](https://travis-ci.org/cienciadedatos/datos.svg?branch=master)](https://travis-ci.org/cienciadedatos/datos)
-[![Coverage
-status](https://codecov.io/gh/cienciadedatos/datos/branch/master/graph/badge.svg)](https://codecov.io/github/cienciadedatos/datos?branch=master)
+[![CRAN status](https://www.r-pkg.org/badges/version/datos)](https://cran.r-project.org/package=datos) [![Travis-CI Build Status](https://travis-ci.org/cienciadedatos/datos.svg?branch=master)](https://travis-ci.org/cienciadedatos/datos) [![Coverage status](https://codecov.io/gh/cienciadedatos/datos/branch/master/graph/badge.svg)](https://codecov.io/github/cienciadedatos/datos?branch=master)
 
-Este paquete provee la traducción al español de conjuntos de datos en
-inglés originalmente disponibles en otros paquetes de R. Los datos
-traducidos son los que se utilizan en los ejemplos del libro [R para
-Ciencia de Datos](es.r4ds.hadley.nz), la versión en español de [R for
-Data Science](r4ds.had.nz.co) de Hadley Wickham & Garrett Grolemund. El
-paquete `datos` puede utilizarse junto con el libro o de manera
-independiente como fuente de datos de práctica en español.
+Este paquete provee la traducción al español de conjuntos de datos en inglés originalmente disponibles en otros paquetes de R. Los datos traducidos son los que se utilizan en los ejemplos del libro [R para Ciencia de Datos](es.r4ds.hadley.nz), la versión en español de [R for Data Science](r4ds.had.nz.co) de Hadley Wickham & Garrett Grolemund. El paquete `datos` puede utilizarse junto con el libro o de manera independiente como fuente de datos de práctica en español.
 
-## Instalación
+Instalación
+-----------
 
-El paquete está disponible en GitHub y puede ser instalado utilizando
-`remotes`:
+El paquete está disponible en GitHub y puede ser instalado utilizando `remotes`:
 
 ``` r
 # install.packages("remotes")
 remotes::install_github("cienciadedatos/datos")
 ```
 
-## Requisitos
+Requisitos
+----------
 
-Este paquete traduce los datos **en el momento**. Esto implica que la
-versión en español de los datos no está contenida como un objeto dentro
-del paquete, sino que se genera al momento de utilizarlos. Por lo tanto,
-para poder usar `datos`, **el paquete que contiene los datos originales
-en inglés debe estar previamente instalado**.
+Este paquete traduce los datos **en el momento**. Esto implica que la versión en español de los datos no está contenida como un objeto dentro del paquete, sino que se genera al momento de utilizarlos. Por lo tanto, para poder usar `datos`, **el paquete que contiene los datos originales en inglés debe estar previamente instalado**.
 
 Los paquetes necesarios son:
 
 | Paquetes     |
-| :----------- |
+|:-------------|
 | nycflights13 |
+| nasaweather  |
+| babynames    |
 | Lahman       |
 | ggplot2      |
 | datasets     |
@@ -46,17 +35,22 @@ Los paquetes necesarios son:
 | forcats      |
 | tibble       |
 | tidyr        |
+| fueleconomy  |
 
-Salvo `gapminder`, `Lahman` y `nycflights13`, todos vienen incluidos en
-el `tidyverse` o en R base.
+El paquete `datasets` es parte de R base y `ggplot2`, `tibble`, `tidyr`, `readr` y `forcats` vienen incluidos en el Tidyverse. Todos los demás deben instalarse individualmente.
 
-## Traducciones
+Si el paquete necesario no está instalado, al tratar de utilizar los datos traducidos aparecerá un error como el siguiente:
 
-Las traducciones disponibles dentro de `datos` son las
-siguientes:
+    > datos::vuelos
+     Error in loadNamespace(name) : there is no package called ‘nycflights13‘
+
+Traducciones
+------------
+
+Las traducciones disponibles dentro de `datos` son las siguientes:
 
 | Nombre        | Título                                                                                   |
-| :------------ | :--------------------------------------------------------------------------------------- |
+|:--------------|:-----------------------------------------------------------------------------------------|
 | aerolineas    | Nombres de aerolíneas                                                                    |
 | aeropuertos   | Datos de aeropuertos                                                                     |
 | aviones       | Datos de aviones                                                                         |
@@ -66,7 +60,6 @@ siguientes:
 | diamantes     | Precio de 50.000 diamantes                                                               |
 | encuesta      | Muestra de variables categóricas de una encuesta social                                  |
 | fiel          | Datos del geiser Viejo Fiel (Old Faithful)                                               |
-| flores        | Datos sobre la flor Iris de Edgar Anderson                                               |
 | millas        | Datos de economía de combustible de 1999 y 2008 para 38 modelos populares de automóviles |
 | mtautos       | Pruebas de ruta de automóviles de Motor Trend                                            |
 | oms           | Datos de tuberculosis de la Organización Mundial de la Salud                             |
@@ -80,13 +73,12 @@ siguientes:
 | tabla5        | Registros de tuberculosis de la Organización Mundial de la Salud (3era variante)         |
 | vuelos        | Datos de vuelos                                                                          |
 
-Además, se incluyen tres set de datos para practicar la manipulación de
-cadenas (*strings*): `oraciones`, `palabras` y `fruta`.
+Los datos para practicar la manipulación de cadenas (*strings*) son `oraciones`, `palabras` y `frutas`.
 
-## Uso
+Uso
+---
 
-La librería `datos` tiene que ser cargada explícitamente en la sesión de
-R:
+El paquete `datos` se carga igual que todos los paquetes de R:
 
 ``` r
 library(datos)
@@ -94,12 +86,7 @@ library(ggplot2)
 library(dplyr)
 ```
 
-Las variables que contienen los datos van a estar disponibles
-inmediatamente para su uso, pero los datos no se van a traducir hasta
-que la variable sea “llamada” explícitamente en el código que se
-escriba. En este ejemplo, los datos `diamantes`, que provienen de
-`ggplot2::diamonds`, se cargan en la memoria de R cuando los llamamos
-por primera vez en español:
+Las variables que contienen los datos van a estar disponibles inmediatamente para su uso, pero los datos no se traducirán hasta que la variable sea "llamada" explícitamente en el código que se escriba. En este ejemplo, el *dataset* `diamantes`, que proviene de `ggplot2::diamonds`, se carga en la memoria de R en el momento en que lo llamamos por primera vez en español:
 
 ``` r
 glimpse(diamantes)
@@ -118,8 +105,7 @@ glimpse(diamantes)
     ## $ y           <dbl> 3.98, 3.84, 4.07, 4.23, 4.35, 3.96, 3.98, 4.11, 3.78…
     ## $ z           <dbl> 2.43, 2.31, 2.31, 2.63, 2.75, 2.48, 2.47, 2.53, 2.49…
 
-Una vez cargado en la memoria, `diamantes` se puede utilizar como
-cualquier otro *dataset* en R:
+Los datos traducidos quedarán cargados durante toda la sesión de R:
 
 ``` r
 diamantes %>%
@@ -130,11 +116,9 @@ diamantes %>%
   labs(title = "Diamantes", subtitle = "Precio y claridad")
 ```
 
-![](README_files/figure-gfm/unnamed-chunk-5-1.png)<!-- -->
+![](README_files/figure-markdown_github/unnamed-chunk-5-1.png)
 
-## Sobre la función para traducir los datos
+Sobre la función para traducir los datos
+----------------------------------------
 
-La traducción de los datos se realiza a través de las funciones
-provistas en el paquete
-[datalang](https://github.com/edgararuiz/datalang) desarrollado por
-Edgar Ruiz.
+La traducción de los datos se realiza a través de las funciones provistas en el paquete [datalang](https://github.com/edgararuiz/datalang) desarrollado por Edgar Ruiz.

--- a/inst/specs/airlines.yml
+++ b/inst/specs/airlines.yml
@@ -3,7 +3,7 @@ df:
   name: aerolineas
 variables:
   carrier:
-    trans: codigo_carrier
+    trans: aerolinea
     desc: abreviación de dos caracteres del nombre de la aerolínea
   name:
     trans: nombre

--- a/inst/specs/faithful.yml
+++ b/inst/specs/faithful.yml
@@ -11,7 +11,7 @@ variables:
 help:
   name: fiel
   alias: fiel
-  title: Datos del geiser Viejo Fiel (Old Faithful)
-  description: Datos de tiempo de duración y espera entre erupciones del Viejo Fiel (Old Faithful), es un geiser del Parque Nacional de Yellowstone, situado en Wyoming, Estados Unidos.
+  title: Datos del géiser Viejo Fiel (Old Faithful)
+  description: Datos de tiempo de duración y espera entre erupciones del géiser Viejo Fiel (Old Faithful), ubicado en el Parque Nacional de Yellowstone, en Wyoming, Estados Unidos.
   usage: fiel
   format: Un data frame con 272 observaciones y 2 columnas

--- a/inst/specs/flights.yml
+++ b/inst/specs/flights.yml
@@ -31,7 +31,7 @@ variables:
     desc: atraso de la llegada en minutos. Valores negativos indican llegada adelantada
   carrier:
     trans: aerolinea
-    desc: abreviación de dos letras de la aerolínea. Ver airlines() para obtener el nombre
+    desc: abreviación de dos letras de la aerolínea. Ver datos::aerolineas para obtener el nombre
   flight:
     trans: vuelo
     desc: número de vuelo
@@ -40,10 +40,10 @@ variables:
     desc: código de cola del avión
   origin:
     trans: origen
-    desc: origen del vuelo. Ver airports() para metadatos adicionales
+    desc: origen del vuelo. Ver datos::aeropuertos para metadatos adicionales
   dest:
     trans: destino
-    desc: destino del vuelo. Ver airports() para metadatos adicionales
+    desc: destino del vuelo. Ver datos::aeropuertos para metadatos adicionales
   air_time:
     trans: tiempo_vuelo
     desc: cantidad de tiempo en aire, en minutos

--- a/inst/specs/flights.yml
+++ b/inst/specs/flights.yml
@@ -31,7 +31,7 @@ variables:
     desc: atraso de la llegada en minutos. Valores negativos indican llegada adelantada
   carrier:
     trans: aerolinea
-    desc: abreviación de dos letras de la aerolínea. Ver datos::aerolineas para obtener el nombre
+    desc: abreviación de dos letras de la aerolínea. Ver `aerolineas` para obtener el nombre
   flight:
     trans: vuelo
     desc: número de vuelo
@@ -40,10 +40,10 @@ variables:
     desc: código de cola del avión
   origin:
     trans: origen
-    desc: origen del vuelo. Ver datos::aeropuertos para metadatos adicionales
+    desc: origen del vuelo. Ver `aeropuertos` para metadatos adicionales
   dest:
     trans: destino
-    desc: destino del vuelo. Ver datos::aeropuertos para metadatos adicionales
+    desc: destino del vuelo. Ver `aeropuertos` para metadatos adicionales
   air_time:
     trans: tiempo_vuelo
     desc: cantidad de tiempo en aire, en minutos


### PR DESCRIPTION
- Como ahora son más paquetes los que no son de R base o el Tidyverse, invertí la redacción de esa parte. Puse un ejemplo del error que aparece si no está instalado el paquete original. Y otros detalles de la redacción. 
- `faithful`:  tilde y arreglo menor en la descripción
- `airplanes`: cambio en el nombre de una variables para que coincida con `flights`
- `flights`: en el archivo de ayuda original se hace referencia a `airplanes` y a `airlines`. Por ahora dejé los nombres en español. ¿Hay manera de que haya un link como en el original?

Cerraré el _issue_ que había abierto. 
