### PR TITLE
Descripción de clima incorrecta

### DIFF
--- a/inst/specs/weather.yml
+++ b/inst/specs/weather.yml
@@ -52,8 +52,6 @@ help:
   name: clima
   alias: clima
   title: Datos de clima
-  description: "Metadatos del clima y los c\u00f3digos de cola de los aviones en el registro de aviaci\u00f3n de la FAA.
-    American Airways (AA) y Envoy Air (MQ) reportan n\u00famero de flota en lugar de n\u00famero de cola, por
-    lo que no es posible trazarlos."
+  description: "Datos meteorol\u00f3gicos horarios para LGA, JFK y EWR."
   usage: clima
   format: Un data.frame con 3,322 líneas y 9 variables


### PR DESCRIPTION
La descripción de los datos `clima` es igual a la descripción de `aviones`. Propongo una traducción de la descripción de la base de datos en inglés. Y se que llego muy tarde pero en vez de `clima`, podría haber sido `tiempo`!