### PR TITLE
Agregando `datos_credito` (asociado a #153)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,6 +52,7 @@ Imports:
     nasaweather,
     nycflights13,
     palmerpenguins,
+    modeldata (>= 1.0.0),
     rlang,
     tibble,
     tidyr,
@@ -63,4 +64,4 @@ ByteCompile: true
 Encoding: UTF-8
 Language: es
 LazyData: true
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 import(babynames)
 import(fueleconomy)
 import(gapminder)
+import(modeldata)
 import(nasaweather)
 import(nycflights13)
 import(palmerpenguins)

--- a/R/datos.R
+++ b/R/datos.R
@@ -20,4 +20,5 @@ NULL
 #' @import nasaweather
 #' @import nycflights13
 #' @import palmerpenguins
+#' @import modeldata
 NULL

--- a/data/data.R
+++ b/data/data.R
@@ -12,6 +12,8 @@ delayedAssign('bateadores',
         eval(parse(file.path(system.file('scripts','bateadores.txt', package = 'datos')))))
 delayedAssign('comunes',
         eval(parse(file.path(system.file('scripts','comunes.txt', package = 'datos')))))
+delayedAssign('datos_credito',
+        eval(parse(file.path(system.file('scripts','datos_credito.txt', package = 'datos')))))
 delayedAssign('diamantes',
         eval(parse(file.path(system.file('scripts','diamantes.txt', package = 'datos')))))
 delayedAssign('fiel',

--- a/inst/scripts/datos_credito.txt
+++ b/inst/scripts/datos_credito.txt
@@ -1,0 +1,67 @@
+translate <- function(spec_file) {
+  pkg_path <- system.file("specs", package = "datos")
+  spec <- yaml::read_yaml(file.path(pkg_path, spec_file))
+  df <- suppressWarnings(eval(parse(text = spec$df$source)))
+  class_df <- class(df)
+  type_df <- NULL
+  if ("function" %in% class_df) {
+    return()
+  }
+  if ("data.frame" %in% class_df) type_df <- "data.frame"
+  if ("tbl_df" %in% class_df) type_df <- "tibble"
+  if ("grouped_df" %in% class_df) type_df <- "grouped_df"
+  if (is.null(type_df)) {
+    return()
+  }
+  if (type_df == "grouped_df") grps <- suppressWarnings(dplyr::group_vars(df))
+  if (type_df == "data.frame") row_names <- rownames(df)
+  if (type_df != "tibble") df <- dplyr::as_tibble(df)
+  vars <- spec$variables
+  var_names <- names(vars)
+  var_names[var_names == "FALSE"] <- "n"
+  var_names[var_names == "TRUE"] <- "y"
+  vars <- vars[var_names != "ROWNAMES"]
+  var_names <- var_names[var_names != "ROWNAMES"]
+  new_names <- as.character(lapply(vars, function(x) x$trans))
+  new_names[new_names == "FALSE"] <- "n"
+  new_names[new_names == "TRUE"] <- "y"
+  new_names <- new_names[new_names != "ROWNAMES"]
+  dfl <- lapply(
+    seq_along(vars),
+    function(x) {
+      cl <- df[, var_names[x]][[1]]
+      from <- names(vars[[x]]$values)
+      if (!is.null(from)) {
+        to <- as.character(vars[[x]]$values[from])
+        if ("factor" %in% class(cl)) {
+          lv <- levels(cl)
+          for (i in seq_along(from)) {
+            lv[lv == from[i]] <- to[i]
+          }
+          levels(cl) <- lv
+        } else {
+          for (i in seq_along(from)) cl[cl == from[i]] <- to[i]
+        }
+      }
+      cl
+    }
+  )
+  dfl <- setNames(dfl, new_names)
+  if (type_df == "tibble") dfl <- dplyr::as_tibble(dfl)
+  if (type_df == "grouped_df") {
+    grps_t <- as.character(lapply(grps, function(x) new_names[var_names == x]))
+    dfl <- dplyr::as_tibble(dfl)
+    dfl <- dplyr::group_by(dfl, !!!rlang::parse_exprs(grps_t))
+  }
+  if (type_df == "data.frame") {
+    if (!is.null(row_names)) {
+      dfl <- as.data.frame(dfl)
+      rownames(dfl) <- row_names
+    } else {
+      dfl <- as.data.frame(dfl)
+    }
+  }
+  dfl
+}
+translate('credit_data.yml')
+

--- a/inst/specs/credit_data.yml
+++ b/inst/specs/credit_data.yml
@@ -1,0 +1,76 @@
+df:
+  source: modeldata::credit_data
+  name: datos_credito
+variables:
+  Status:
+    trans: Estado
+    desc: "estado del cr\u00E9dito"
+    values:
+      bad: malo
+      good: bueno
+  Seniority:
+    trans: Antiguedad
+    desc: "Antig\u00FCedad laboral"
+  Home:
+    trans: Vivienda
+    desc: tipo de propiedad de la vivienda
+    values:
+      ignore: ignorar
+      other: otra
+      owner: propietario
+      parents: padres
+      priv: privado
+      rent: alquila
+  Time:
+    trans: Plazo
+    desc: "Plazo del cr\u00E9dito en meses"
+  Age:
+    trans: Edad
+    desc: edad del cliente
+  Marital:
+    trans: EstadoCivil
+    desc: estado civil
+    values:
+      divorced: divorciado
+      married: casado
+      separated: separado
+      single: soltero
+      widow: viudo
+  Records:
+    trans: Registros
+    desc: existencia de registros previos
+    values:
+      "no": "no"
+      "yes": "s\u00ed"
+  Job:
+    trans: Trabajo
+    desc: tipo de trabajo
+    values:
+      fixed: fijo
+      freelance: freelance
+      others: otros
+      partime: tiempo parcial
+  Expenses:
+    trans: Gastos
+    desc: cantidad o monto de gastos
+  Income:
+    trans: Ingresos
+    desc: cantidad o monto de ingresos
+  Assets:
+    trans: Activos
+    desc: cantidad o monto de activos
+  Debt:
+    trans: Deuda
+    desc: cantidad o monto de deudas
+  Amount:
+    trans: Cantidad
+    desc: "cantidad solicitada de pr\u00E9stamo"
+  Price:
+    trans: Precio
+    desc: "precio del cr\u00E9dito"
+help:
+  name: datos_credito
+  alias: datos_credito
+  title: "Datos de cr\u00E9dito"
+  description: Datos asociado a creditos de consumo.
+  format: Un data.frame con 14 filas y 4454 columnas

--- a/man/datos-package.Rd
+++ b/man/datos-package.Rd
@@ -6,7 +6,7 @@
 \alias{datos-package}
 \title{datos: Traduce al Español Varios Conjuntos de Datos de Práctica}
 \description{
-\if{html}{\figure{logo.png}{options: align='right' alt='logo' width='120'}}
+\if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
 Provee una versión traducida de los siguientes conjuntos de datos: 'airlines', 'airports', 'AwardsManagers', 'babynames', 'Batting', 'diamonds', 'faithful', 'fueleconomy', 'Fielding', 'flights', 'gapminder', 'gss_cat', 'iris', 'Managers', 'mpg', 'mtcars', 'atmos', 'palmerpenguins', 'People, 'Pitching', 'planes', 'presidential', 'table1', 'table2', 'table3', 'table4a', 'table4b', 'table5', 'vehicles', 'weather', 'who'. English: It provides a Spanish translated version of the datasets listed above.
 }

--- a/man/datos_credito.rd
+++ b/man/datos_credito.rd
@@ -1,0 +1,23 @@
+\docType{data}
+\name{datos_credito}
+\alias{datos_credito}
+\title{Datos de crédito}
+\format{Un data.frame con 14 filas y 4454 columnas
+\describe{
+\item{Estado}{estado del crédito}
+\item{Antiguedad}{Antigüedad laboral}
+\item{Vivienda}{tipo de propiedad de la vivienda}
+\item{Plazo}{Plazo del crédito en meses}
+\item{Edad}{edad del cliente}
+\item{EstadoCivil}{estado civil}
+\item{Registros}{existencia de registros previos}
+\item{Trabajo}{tipo de trabajo}
+\item{Gastos}{cantidad o monto de gastos}
+\item{Ingresos}{cantidad o monto de ingresos}
+\item{Activos}{cantidad o monto de activos}
+\item{Deuda}{cantidad o monto de deudas}
+\item{Cantidad}{cantidad solicitada de préstamo}
+\item{Precio}{precio del crédito}
+}}
+\description{Datos asociado a creditos de consumo.}
+\keyword{datasets}


### PR DESCRIPTION
Hola,

Este PR viene a la idea de agregar algunos conjunto de datos del paquete `{modeldata}` que se utiliza a lo largo del libro [Tidy Modeling with R](https://www.tmwr.org/). Particularmente, en este PR se incorpora la traducción de los datos `modeldata::credit_data`.

El proceso de este PR sigue el siguiente patrón:

1. Crear  `inst/scripts/datos_credito.txt` y `inst/specs/credit_data.yml`. 
1. Correr `datos:::folder_rd()` `datos:::data_script()`
1. Modificar `DESCRIPTION` para agregar  `modeldata (>= 1.0.0)` a los imports, como tambien el archivo `datos.R`. La version 1.0.0 es necesaria dado que en dicha version se incorpora `lazyData: true` en el `DESCRIPTION` de `{modeldata}` (https://github.com/tidymodels/modeldata/issues/44)

Considerar que se utlizaron comillas en la descripción de los valores debido a que `yes` y `no` son palabras reservadas de YAML.

Cualquier cambio requerido me comentan.
Un gran saludo,
